### PR TITLE
PPTP authentication dialog: focus is now automatically set on "password" textbox

### DIFF
--- a/vpn/pptp/pptpauth.cpp
+++ b/vpn/pptp/pptpauth.cpp
@@ -39,6 +39,8 @@ PptpAuthWidget::PptpAuthWidget(const NetworkManager::VpnSetting::Ptr &setting, Q
     d->ui.setupUi(this);
     connect(d->ui.chkShowPassword, SIGNAL(toggled(bool)), this, SLOT(showPasswordsToggled(bool)));
 
+    d->ui.lePassword->setFocus(Qt::OtherFocusReason);
+
     KAcceleratorManager::manage(this);
 }
 

--- a/vpn/pptp/pptpauth.ui
+++ b/vpn/pptp/pptpauth.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>372</width>
+    <width>429</width>
     <height>85</height>
    </rect>
   </property>
@@ -33,7 +33,7 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="1">
+   <item row="1" column="0" colspan="2">
     <widget class="QCheckBox" name="chkShowPassword">
      <property name="text">
       <string>Show password</string>


### PR DESCRIPTION
Also:

* The dialog's width is now the same as width of OpenVPN authentication dialog,
* "Show password" checkbox is now aligned to the left.

============================================

Motivation for this change:

1. User experience: when keyboard focus is automatically set on "password" textbox, then user can start entering password immediately when the dialog is displayed.
2. Consistency of look&behaviour between PPTP and OpenVPN authentication dialogs.
