### PR TITLE
openvpn import: avoid enabling TCP if the remote has been set on another line

### DIFF
--- a/vpn/openvpn/openvpn.cpp
+++ b/vpn/openvpn/openvpn.cpp
@@ -363,6 +363,9 @@ NMVariantMapMap OpenVpnUiPlugin::importConnectionSettings(const QString &fileNam
             continue;
         }
         if (key_value[0] == REMOTE_TAG) {
+            if (have_remote) {
+                continue;
+            }
             if (key_value.count() >= 2 && key_value.count() <= 4) {
                 QString remote = key_value[1];
                 if (remote.startsWith(QLatin1Char('\'')) || remote.startsWith(QLatin1Char('"'))) {


### PR DESCRIPTION
When importing an ovpn file, we take the first 'remote' line as the connection's remote. If a different 'remote' line specifies the use of TCP, that should not pertain to the line that was chosen.

This fixes a situation where an ovpn file contains multiple 'remote' lines, the first one with udp and a later line with tcp. What happens before the fix is that the imported connection uses the IP address of the first line, but with TCP, and connection fails.