### PR TITLE
Strongswan plugin: added support for Remote Identity and for password options

### DIFF
--- a/vpn/strongswan/nm-strongswan-service.h
+++ b/vpn/strongswan/nm-strongswan-service.h
@@ -28,6 +28,8 @@
 #define NM_STRONGSWAN_PROPOSAL "proposal"
 #define NM_STRONGSWAN_IKE "ike"
 #define NM_STRONGSWAN_ESP "esp"
+#define NM_STRONGSWAN_RIDENTITY "remote-identity"
+#define NM_STRONGSWAN_POPTION "password-flags"
 
 #define NM_STRONGSWAN_AUTH_KEY "key"
 #define NM_STRONGSWAN_AUTH_AGENT "agent"

--- a/vpn/strongswan/strongswanprop.ui
+++ b/vpn/strongswan/strongswanprop.ui
@@ -53,6 +53,26 @@
       <item row="1" column="1">
        <widget class="KUrlRequester" name="leGatewayCertificate"/>
       </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="textLabel3_1">
+        <property name="text">
+         <string>Identity:</string>
+        </property>
+        <property name="wordWrap">
+         <bool>false</bool>
+        </property>
+        <property name="buddy">
+         <cstring>leRIdentity</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QLineEdit" name="leRIdentity">
+        <property name="clearButtonEnabled">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>

--- a/vpn/strongswan/strongswanprop.ui
+++ b/vpn/strongswan/strongswanprop.ui
@@ -62,12 +62,12 @@
          <bool>false</bool>
         </property>
         <property name="buddy">
-         <cstring>leRIdentity</cstring>
+         <cstring>leRemoteIdentity</cstring>
         </property>
        </widget>
       </item>
       <item row="2" column="1">
-       <widget class="QLineEdit" name="leRIdentity">
+       <widget class="QLineEdit" name="leRemoteIdentity">
         <property name="clearButtonEnabled">
          <bool>true</bool>
         </property>

--- a/vpn/strongswan/strongswanwidget.cpp
+++ b/vpn/strongswan/strongswanwidget.cpp
@@ -69,9 +69,9 @@ void StrongswanSettingWidget::loadConfig(const NetworkManager::Setting::Ptr &set
     d->ui.leGatewayCertificate->setUrl(QUrl::fromLocalFile(dataMap[NM_STRONGSWAN_CERTIFICATE]));
     
     // Remote Identity
-    const QString ridentity = dataMap[NM_STRONGSWAN_RIDENTITY];
-    if (!ridentity.isEmpty()) {
-        d->ui.leRIdentity->setText(ridentity);
+    const QString rIdentity = dataMap[NM_STRONGSWAN_RIDENTITY];
+    if (!rIdentity.isEmpty()) {
+        d->ui.leRemoteIdentity->setText(rIdentity);
     }
 
     // Authentication
@@ -143,8 +143,8 @@ QVariantMap StrongswanSettingWidget::setting() const
     }
         
     // Server Identity (Right Identity)
-    if (!d->ui.leRIdentity->text().isEmpty()) {
-        data.insert(NM_STRONGSWAN_RIDENTITY, d->ui.leRIdentity->text());
+    if (!d->ui.leRemoteIdentity->text().isEmpty()) {
+        data.insert(NM_STRONGSWAN_RIDENTITY, d->ui.leRemoteIdentity->text());
     }
 
     // Authentication

--- a/vpn/strongswan/strongswanwidget.cpp
+++ b/vpn/strongswan/strongswanwidget.cpp
@@ -29,6 +29,10 @@ StrongswanSettingWidget::StrongswanSettingWidget(const NetworkManager::VpnSettin
     d->ui.setupUi(this);
 
     d->setting = setting;
+    
+    // Enables combo box for password
+    d->ui.leUserPassword->setPasswordOptionsEnabled(true);
+    d->ui.leUserPassword->setPasswordNotRequiredEnabled(true);
 
     // Connect for setting check
     watchChangedSetting();
@@ -63,6 +67,12 @@ void StrongswanSettingWidget::loadConfig(const NetworkManager::Setting::Ptr &set
     }
     // Certificate
     d->ui.leGatewayCertificate->setUrl(QUrl::fromLocalFile(dataMap[NM_STRONGSWAN_CERTIFICATE]));
+    
+    // Remote Identity
+    const QString ridentity = dataMap[NM_STRONGSWAN_RIDENTITY];
+    if (!ridentity.isEmpty()) {
+        d->ui.leRIdentity->setText(ridentity);
+    }
 
     // Authentication
     const QString method = dataMap[NM_STRONGSWAN_METHOD];
@@ -78,6 +88,22 @@ void StrongswanSettingWidget::loadConfig(const NetworkManager::Setting::Ptr &set
     } else if (method == QLatin1String(NM_STRONGSWAN_AUTH_EAP)) {
         d->ui.cmbMethod->setCurrentIndex(StrongswanSettingWidgetPrivate::Eap);
         d->ui.leUserName->setText(dataMap[NM_STRONGSWAN_USER]);
+        
+        PasswordField *passwordField = d->ui.leUserPassword;
+        const NetworkManager::Setting::SecretFlags type = (NetworkManager::Setting::SecretFlags)dataMap[NM_STRONGSWAN_POPTION].toInt();
+        if (type.testFlag(NetworkManager::Setting::None)) {
+            passwordField->setPasswordOption(PasswordField::StoreForAllUsers);
+        } else if (type.testFlag(NetworkManager::Setting::AgentOwned)) {
+            passwordField->setPasswordOption(PasswordField::StoreForUser);
+        } else if (type.testFlag(NetworkManager::Setting::NotSaved)) {
+            passwordField->setPasswordOption(PasswordField::AlwaysAsk);
+        } else if (type.testFlag(NetworkManager::Setting::NotRequired)) {
+            passwordField->setPasswordOption(PasswordField::NotRequired);
+        }
+        // Strongswan always reads the password inside [vpn-secrets] section for global users
+        NetworkManager::VpnSetting::Ptr vpnSetting = setting.staticCast<NetworkManager::VpnSetting>();
+        const NMStringMap secrets = vpnSetting->secrets();
+        d->ui.leUserPassword->setText(secrets.value(NM_STRONGSWAN_SECRET));
     }
 
     // Settings
@@ -115,6 +141,11 @@ QVariantMap StrongswanSettingWidget::setting() const
     if (!certificate.isEmpty()) {
         data.insert(NM_STRONGSWAN_CERTIFICATE, certificate);
     }
+        
+    // Server Identity (Right Identity)
+    if (!d->ui.leRIdentity->text().isEmpty()) {
+        data.insert(NM_STRONGSWAN_RIDENTITY, d->ui.leRIdentity->text());
+    }
 
     // Authentication
     switch (d->ui.cmbMethod->currentIndex()) {
@@ -147,6 +178,23 @@ QVariantMap StrongswanSettingWidget::setting() const
             data.insert(NM_STRONGSWAN_USER, d->ui.leUserName->text());
         }
         // StrongSwan-nm 1.2 does not appear to be able to save secrets, the must be entered through the auth dialog
+        // flags for password
+        PasswordField *passwordField = d->ui.leUserPassword;
+        const PasswordField::PasswordOption option = passwordField->passwordOption();
+        if (option == PasswordField::StoreForAllUsers) {
+            data.insert(NM_STRONGSWAN_POPTION, QString::number(NetworkManager::Setting::None));
+        } else if (option == PasswordField::StoreForUser) {
+            data.insert(NM_STRONGSWAN_POPTION, QString::number(NetworkManager::Setting::AgentOwned));
+        } else if (option == PasswordField::AlwaysAsk) {
+            data.insert(NM_STRONGSWAN_POPTION, QString::number(NetworkManager::Setting::NotSaved));
+        } else {
+            data.insert(NM_STRONGSWAN_POPTION, QString::number(NetworkManager::Setting::NotRequired));
+        }
+        // Saving the password
+        if (!d->ui.leUserPassword->text().isEmpty()) {
+            secretData = d->setting->secrets();
+            secretData.insert(NM_STRONGSWAN_SECRET, d->ui.leUserPassword->text());
+        }
     }
 
     // Options


### PR DESCRIPTION
These changes affects only strongswan plugin.

Support for explicitly setting Remote Identity was added. This is a feature that I needed to fully validate the certificate of some servers with internal CA certificate, otherwise it fails.

Also, the password option was enabled and added saving/loading support for password strings. Otherwise, the only way to set it is through the nm-applet.

I'm testing these changes with Plasma 5.24.4 (Ubuntu 22.04).
I hope this can also be helpful to others. 