### PR TITLE
Adjustments for nm-ssh master branch

### DIFF
--- a/vpn/ssh/nm-ssh-service.h
+++ b/vpn/ssh/nm-ssh-service.h
@@ -19,12 +19,14 @@
 #define NM_SSH_KEY_NETMASK "netmask"
 #define NM_SSH_KEY_PORT "port"
 #define NM_SSH_KEY_TUNNEL_MTU "tunnel-mtu"
-#define NM_SSH_KEY_EXTRA_OPTS "extra-opts"
 #define NM_SSH_KEY_REMOTE_DEV "remote-dev"
 #define NM_SSH_KEY_SSH_AUTH_SOCK "ssh-auth-sock"
 #define NM_SSH_KEY_TAP_DEV "tap-dev"
 #define NM_SSH_KEY_REMOTE_USERNAME "remote-username"
-#define NM_SSH_KEY_NO_DEFAULT_ROUTE "no-default-route"
+#define NM_SSH_KEY_NO_TUNNEL_INTERFACE "no-tunnel-interface"
+#define NM_SSH_KEY_SOCKS_BIND_ADDRESS "socks-bind-address"
+#define NM_SSH_KEY_LOCAL_BIND_ADDRESS "local-bind-address"
+#define NM_SSH_KEY_REMOTE_BIND_ADDRESS "remote-bind-address"
 #define NM_SSH_KEY_IP_6 "ip-6"
 #define NM_SSH_KEY_REMOTE_IP_6 "remote-ip-6"
 #define NM_SSH_KEY_LOCAL_IP_6 "local-ip-6"
@@ -36,8 +38,11 @@
 #define NM_SSH_DEFAULT_PORT 22
 #define NM_SSH_DEFAULT_MTU 1500
 #define NM_SSH_DEFAULT_REMOTE_DEV 100
-#define NM_SSH_DEFAULT_EXTRA_OPTS "-o ServerAliveInterval=10 -o TCPKeepAlive=yes"
 #define NM_SSH_DEFAULT_REMOTE_USERNAME "root"
+#define NM_SSH_DEFAULT_NO_TUNNEL_INTERFACE "dummy0"
+#define NM_SSH_DEFAULT_SOCKS_BIND_ADDRESS "localhost:8080"
+#define NM_SSH_DEFAULT_LOCAL_BIND_ADDRESS "localhost:8080:localhost:8080"
+#define NM_SSH_DEFAULT_REMOTE_BIND_ADDRESS "localhost:8080:localhost:8080"
 
 #define NM_SSH_AUTH_TYPE_SSH_AGENT "ssh-agent"
 #define NM_SSH_AUTH_TYPE_PASSWORD "password"

--- a/vpn/ssh/sshadvanced.ui
+++ b/vpn/ssh/sshadvanced.ui
@@ -63,24 +63,6 @@
     </layout>
    </item>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_3">
-     <item>
-      <widget class="QCheckBox" name="chk_extraSshOptions">
-       <property name="text">
-        <string>Extra SSH options:</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLineEdit" name="le_extraSshOptions">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item>
     <layout class="QHBoxLayout" name="horizontalLayout_4">
      <item>
       <widget class="QCheckBox" name="chk_remoteDeviceNumber">
@@ -127,11 +109,76 @@
     </layout>
    </item>
    <item>
-    <widget class="QCheckBox" name="chk_doNotReplaceDefaultRoute">
-     <property name="text">
-      <string>Do not replace default route</string>
-     </property>
-    </widget>
+    <layout class="QHBoxLayout" name="horizontalLayout_5">
+     <item>
+      <widget class="QCheckBox" name="chk_noTunnelInterface">
+       <property name="text">
+        <string>No tunnel (specify dummy interface):</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="le_noTunnelInterface">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_5">
+     <item>
+      <widget class="QCheckBox" name="chk_socksBindAddress">
+       <property name="text">
+        <string>SOCKS bind addresses (-D, space separated):</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="le_socksBindAddress">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_5">
+     <item>
+      <widget class="QCheckBox" name="chk_localBindAddress">
+       <property name="text">
+        <string>Local bind addresses (-L, space separated):</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="le_localBindAddress">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_5">
+     <item>
+      <widget class="QCheckBox" name="chk_remoteBindAddress">
+       <property name="text">
+        <string>Remote bind addresses (-L, space separated):</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="le_remoteBindAddress">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
   </layout>
  </widget>
@@ -170,22 +217,6 @@
    </hints>
   </connection>
   <connection>
-   <sender>chk_extraSshOptions</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>le_extraSshOptions</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>84</x>
-     <y>115</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>378</x>
-     <y>115</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
    <sender>chk_remoteDeviceNumber</sender>
    <signal>toggled(bool)</signal>
    <receiver>sb_remoteDeviceNumber</receiver>
@@ -205,6 +236,70 @@
    <sender>chk_remoteUsername</sender>
    <signal>toggled(bool)</signal>
    <receiver>le_remoteUsername</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>83</x>
+     <y>235</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>378</x>
+     <y>235</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>chk_noTunnelInterface</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>le_noTunnelInterface</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>83</x>
+     <y>235</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>378</x>
+     <y>235</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>chk_socksBindAddress</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>le_socksBindAddress</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>83</x>
+     <y>235</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>378</x>
+     <y>235</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>chk_localBindAddress</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>le_localBindAddress</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>83</x>
+     <y>235</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>378</x>
+     <y>235</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>chk_remoteBindAddress</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>le_remoteBindAddress</receiver>
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">

--- a/vpn/ssh/sshwidget.cpp
+++ b/vpn/ssh/sshwidget.cpp
@@ -76,9 +76,12 @@ SshSettingWidget::SshSettingWidget(const NetworkManager::VpnSetting::Ptr &settin
     d->ui.passwordWidget->setVisible(false);
     d->advUi.sb_useCustomGatewayPort->setValue(NM_SSH_DEFAULT_PORT);
     d->advUi.sb_useCustomTunnelMtu->setValue(NM_SSH_DEFAULT_MTU);
-    d->advUi.le_extraSshOptions->setText(QLatin1String(NM_SSH_DEFAULT_EXTRA_OPTS));
     d->advUi.sb_remoteDeviceNumber->setValue(NM_SSH_DEFAULT_REMOTE_DEV);
     d->advUi.le_remoteUsername->setText(QLatin1String(NM_SSH_DEFAULT_REMOTE_USERNAME));
+    d->advUi.le_noTunnelInterface->setText(QLatin1String(NM_SSH_DEFAULT_NO_TUNNEL_INTERFACE));
+    d->advUi.le_socksBindAddress->setText(QLatin1String(NM_SSH_DEFAULT_SOCKS_BIND_ADDRESS));
+    d->advUi.le_localBindAddress->setText(QLatin1String(NM_SSH_DEFAULT_LOCAL_BIND_ADDRESS));
+    d->advUi.le_remoteBindAddress->setText(QLatin1String(NM_SSH_DEFAULT_REMOTE_BIND_ADDRESS));
 
     KAcceleratorManager::manage(this);
 
@@ -168,12 +171,6 @@ void SshSettingWidget::loadConfig(const NetworkManager::Setting::Ptr &setting)
         d->advUi.sb_useCustomTunnelMtu->setValue(customMtu.toInt());
     }
 
-    const QString extraSshOptions = dataMap[QLatin1String(NM_SSH_KEY_EXTRA_OPTS)];
-    if (!extraSshOptions.isEmpty()) {
-        d->advUi.chk_extraSshOptions->setChecked(true);
-        d->advUi.le_extraSshOptions->setText(extraSshOptions);
-    }
-
     const QString remoteDeviceNumber = dataMap[QLatin1String(NM_SSH_KEY_REMOTE_DEV)];
     if (!remoteDeviceNumber.isEmpty()) {
         d->advUi.chk_remoteDeviceNumber->setChecked(true);
@@ -193,11 +190,28 @@ void SshSettingWidget::loadConfig(const NetworkManager::Setting::Ptr &setting)
         d->advUi.le_remoteUsername->setText(remoteUsername);
     }
 
-    const QString doNotReplaceDefaultRoute = dataMap[QLatin1String(NM_SSH_KEY_NO_DEFAULT_ROUTE)];
-    if (!doNotReplaceDefaultRoute.isEmpty()) {
-        if (doNotReplaceDefaultRoute == QLatin1String("yes")) {
-            d->advUi.chk_doNotReplaceDefaultRoute->setChecked(true);
-        }
+    const QString noTunnelInterface = dataMap[QLatin1String(NM_SSH_KEY_NO_TUNNEL_INTERFACE)];
+    if (!noTunnelInterface.isEmpty()) {
+        d->advUi.chk_noTunnelInterface->setChecked(true);
+        d->advUi.le_noTunnelInterface->setText(noTunnelInterface);
+    }
+
+    const QString socksBindAddress = dataMap[QLatin1String(NM_SSH_KEY_SOCKS_BIND_ADDRESS)];
+    if (!socksBindAddress.isEmpty()) {
+        d->advUi.chk_socksBindAddress->setChecked(true);
+        d->advUi.le_socksBindAddress->setText(socksBindAddress);
+    }
+
+    const QString localBindAddress = dataMap[QLatin1String(NM_SSH_KEY_LOCAL_BIND_ADDRESS)];
+    if (!localBindAddress.isEmpty()) {
+        d->advUi.chk_localBindAddress->setChecked(true);
+        d->advUi.le_localBindAddress->setText(localBindAddress);
+    }
+
+    const QString remoteBindAddress = dataMap[QLatin1String(NM_SSH_KEY_REMOTE_BIND_ADDRESS)];
+    if (!remoteBindAddress.isEmpty()) {
+        d->advUi.chk_remoteBindAddress->setChecked(true);
+        d->advUi.le_remoteBindAddress->setText(remoteBindAddress);
     }
 
     loadSecrets(setting);
@@ -285,10 +299,6 @@ QVariantMap SshSettingWidget::setting() const
         data.insert(QLatin1String(NM_SSH_KEY_TUNNEL_MTU), QString::number(d->advUi.sb_useCustomTunnelMtu->value()));
     }
 
-    if (d->advUi.chk_extraSshOptions->isChecked()) {
-        data.insert(QLatin1String(NM_SSH_KEY_EXTRA_OPTS), d->advUi.le_extraSshOptions->text());
-    }
-
     if (d->advUi.chk_remoteDeviceNumber->isChecked()) {
         data.insert(QLatin1String(NM_SSH_KEY_REMOTE_DEV), QString::number(d->advUi.sb_remoteDeviceNumber->value()));
     }
@@ -301,8 +311,20 @@ QVariantMap SshSettingWidget::setting() const
         data.insert(QLatin1String(NM_SSH_KEY_REMOTE_USERNAME), d->advUi.le_remoteUsername->text());
     }
 
-    if (d->advUi.chk_doNotReplaceDefaultRoute->isChecked()) {
-        data.insert(QLatin1String(NM_SSH_KEY_NO_DEFAULT_ROUTE), QLatin1String("yes"));
+    if (d->advUi.chk_noTunnelInterface->isChecked()) {
+        data.insert(QLatin1String(NM_SSH_KEY_NO_TUNNEL_INTERFACE), d->advUi.le_noTunnelInterface->text());
+    }
+
+    if (d->advUi.chk_socksBindAddress->isChecked()) {
+        data.insert(QLatin1String(NM_SSH_KEY_SOCKS_BIND_ADDRESS), d->advUi.le_socksBindAddress->text());
+    }
+
+    if (d->advUi.chk_localBindAddress->isChecked()) {
+        data.insert(QLatin1String(NM_SSH_KEY_LOCAL_BIND_ADDRESS), d->advUi.le_localBindAddress->text());
+    }
+
+    if (d->advUi.chk_remoteBindAddress->isChecked()) {
+        data.insert(QLatin1String(NM_SSH_KEY_REMOTE_BIND_ADDRESS), d->advUi.le_remoteBindAddress->text());
     }
 
     // save it all


### PR DESCRIPTION
 * Remove NM_SSH_KEY_EXTRA_OPTS
 * Remove NM_SSH_KEY_NO_DEFAULT_ROUTE
 * Add NM_SSH_KEY_NO_TUNNEL_INTERFACE
 * Add NM_SSH_KEY_SOCKS_BIND_ADDRESS
 * Add NM_SSH_KEY_LOCAL_BIND_ADDRESS
 * Add NM_SSH_KEY_REMOTE_BIND_ADDRESS

---

I'll also add that I'm grateful for your maintenance of the plasma port of NetworkManager-ssh (I'm the main maintainer). If there's anything I can do to improve the cooperation, please let me know.

The changes above *HAVE NOT BEEN TESTED* and I probably didn't do a good job with the `sshadvanced.ui` file as I'm unfamiliar with is. The changes are outlined in the commit message (and above) as some keys have been added, and a couple have been removed. I've tagged those changes as 1.3.0.