### PR TITLE
Fix typo in the SPDX Identifier of CMakeLists.txt

### DIFF
--- a/kcms/CMakeLists.txt
+++ b/kcms/CMakeLists.txt
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: 2025 Carl Schwan <carl@carlschwan.eu>
-# SPDX-License-Identifier: BSD-2-Clauses
+# SPDX-License-Identifier: BSD-2-Clause
 
 add_subdirectory(kcm_cellularnetwork)
 add_subdirectory(kcm_hotspot)


### PR DESCRIPTION
* I noticed this while looking into openSUSE Leap 16.0 plasma6-nm legal review.